### PR TITLE
fix(mpp-idea): replace Material Icons with local IdeaComposeIcons

### DIFF
--- a/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/toolwindow/IdeaAgentApp.kt
+++ b/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/toolwindow/IdeaAgentApp.kt
@@ -24,7 +24,6 @@ import cc.unitmesh.devins.idea.editor.IdeaInputTrigger
 import cc.unitmesh.devins.idea.renderer.JewelRenderer
 import cc.unitmesh.devins.idea.toolwindow.codereview.IdeaCodeReviewContent
 import cc.unitmesh.devins.idea.toolwindow.codereview.IdeaCodeReviewViewModel
-import cc.unitmesh.devins.ui.compose.icons.AutoDevComposeIcons
 import cc.unitmesh.devins.ui.compose.theme.AutoDevColors
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.editor.ex.EditorEx
@@ -297,7 +296,7 @@ private fun ToolCallBubble(item: JewelRenderer.TimelineItem.ToolCallItem) {
                         style = JewelTheme.defaultTextStyle.copy(color = statusColor)
                     )
                     Icon(
-                        imageVector = AutoDevComposeIcons.Build,
+                        imageVector = IdeaComposeIcons.Build,
                         contentDescription = "Tool",
                         modifier = Modifier.size(14.dp),
                         tint = JewelTheme.globalColors.text.normal
@@ -349,7 +348,7 @@ private fun ErrorBubble(message: String) {
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Icon(
-                    imageVector = AutoDevComposeIcons.Error,
+                    imageVector = IdeaComposeIcons.Error,
                     contentDescription = "Error",
                     modifier = Modifier.size(16.dp),
                     tint = AutoDevColors.Red.c400
@@ -387,7 +386,7 @@ private fun TaskCompleteBubble(item: JewelRenderer.TimelineItem.TaskCompleteItem
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Icon(
-                    imageVector = if (item.success) AutoDevComposeIcons.CheckCircle else AutoDevComposeIcons.Error,
+                    imageVector = if (item.success) IdeaComposeIcons.CheckCircle else IdeaComposeIcons.Error,
                     contentDescription = if (item.success) "Success" else "Failed",
                     modifier = Modifier.size(16.dp),
                     tint = if (item.success) AutoDevColors.Green.c400 else AutoDevColors.Red.c400
@@ -463,7 +462,7 @@ private fun AgentTabsHeader(
             }
             IconButton(onClick = onSettings) {
                 Icon(
-                    imageVector = AutoDevComposeIcons.Settings,
+                    imageVector = IdeaComposeIcons.Settings,
                     contentDescription = "Settings",
                     modifier = Modifier.size(16.dp),
                     tint = JewelTheme.globalColors.text.normal

--- a/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/toolwindow/IdeaComposeIcons.kt
+++ b/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/toolwindow/IdeaComposeIcons.kt
@@ -1,0 +1,185 @@
+package cc.unitmesh.devins.idea.toolwindow
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+/**
+ * Icon provider for IntelliJ IDEA Compose UI.
+ * These icons are defined using ImageVector paths to avoid dependency on Material Icons
+ * which is not available in IntelliJ's Compose environment.
+ */
+object IdeaComposeIcons {
+
+    /**
+     * Settings icon (gear/cog)
+     */
+    val Settings: ImageVector by lazy {
+        ImageVector.Builder(
+            name = "Settings",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f
+        ).apply {
+            path(
+                fill = SolidColor(Color.Black),
+                pathFillType = PathFillType.EvenOdd
+            ) {
+                // Gear icon path
+                moveTo(19.14f, 12.94f)
+                curveToRelative(0.04f, -0.31f, 0.06f, -0.63f, 0.06f, -0.94f)
+                curveToRelative(0f, -0.32f, -0.02f, -0.64f, -0.07f, -0.94f)
+                lineToRelative(2.03f, -1.58f)
+                curveToRelative(0.18f, -0.14f, 0.23f, -0.41f, 0.12f, -0.61f)
+                lineToRelative(-1.92f, -3.32f)
+                curveToRelative(-0.12f, -0.22f, -0.37f, -0.29f, -0.59f, -0.22f)
+                lineToRelative(-2.39f, 0.96f)
+                curveToRelative(-0.5f, -0.38f, -1.03f, -0.7f, -1.62f, -0.94f)
+                lineToRelative(-0.36f, -2.54f)
+                curveToRelative(-0.04f, -0.24f, -0.24f, -0.41f, -0.48f, -0.41f)
+                horizontalLineToRelative(-3.84f)
+                curveToRelative(-0.24f, 0f, -0.43f, 0.17f, -0.47f, 0.41f)
+                lineToRelative(-0.36f, 2.54f)
+                curveToRelative(-0.59f, 0.24f, -1.13f, 0.56f, -1.62f, 0.94f)
+                lineToRelative(-2.39f, -0.96f)
+                curveToRelative(-0.22f, -0.08f, -0.47f, 0f, -0.59f, 0.22f)
+                lineTo(2.74f, 8.87f)
+                curveToRelative(-0.12f, 0.21f, -0.08f, 0.47f, 0.12f, 0.61f)
+                lineToRelative(2.03f, 1.58f)
+                curveToRelative(-0.05f, 0.3f, -0.09f, 0.63f, -0.09f, 0.94f)
+                curveToRelative(0f, 0.31f, 0.02f, 0.64f, 0.07f, 0.94f)
+                lineToRelative(-2.03f, 1.58f)
+                curveToRelative(-0.18f, 0.14f, -0.23f, 0.41f, -0.12f, 0.61f)
+                lineToRelative(1.92f, 3.32f)
+                curveToRelative(0.12f, 0.22f, 0.37f, 0.29f, 0.59f, 0.22f)
+                lineToRelative(2.39f, -0.96f)
+                curveToRelative(0.5f, 0.38f, 1.03f, 0.7f, 1.62f, 0.94f)
+                lineToRelative(0.36f, 2.54f)
+                curveToRelative(0.05f, 0.24f, 0.24f, 0.41f, 0.48f, 0.41f)
+                horizontalLineToRelative(3.84f)
+                curveToRelative(0.24f, 0f, 0.44f, -0.17f, 0.47f, -0.41f)
+                lineToRelative(0.36f, -2.54f)
+                curveToRelative(0.59f, -0.24f, 1.13f, -0.56f, 1.62f, -0.94f)
+                lineToRelative(2.39f, 0.96f)
+                curveToRelative(0.22f, 0.08f, 0.47f, 0f, 0.59f, -0.22f)
+                lineToRelative(1.92f, -3.32f)
+                curveToRelative(0.12f, -0.22f, 0.07f, -0.47f, -0.12f, -0.61f)
+                lineToRelative(-2.01f, -1.58f)
+                close()
+                moveTo(12f, 15.6f)
+                curveToRelative(-1.98f, 0f, -3.6f, -1.62f, -3.6f, -3.6f)
+                reflectiveCurveToRelative(1.62f, -3.6f, 3.6f, -3.6f)
+                reflectiveCurveToRelative(3.6f, 1.62f, 3.6f, 3.6f)
+                reflectiveCurveToRelative(-1.62f, 3.6f, -3.6f, 3.6f)
+                close()
+            }
+        }.build()
+    }
+
+    /**
+     * Build/Tool icon (wrench)
+     */
+    val Build: ImageVector by lazy {
+        ImageVector.Builder(
+            name = "Build",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f
+        ).apply {
+            path(
+                fill = SolidColor(Color.Black)
+            ) {
+                moveTo(22.7f, 19f)
+                lineToRelative(-9.1f, -9.1f)
+                curveToRelative(0.9f, -2.3f, 0.4f, -5f, -1.5f, -6.9f)
+                curveToRelative(-2f, -2f, -5f, -2.4f, -7.4f, -1.3f)
+                lineTo(9f, 6f)
+                lineTo(6f, 9f)
+                lineTo(1.6f, 4.7f)
+                curveTo(0.4f, 7.1f, 0.9f, 10.1f, 2.9f, 12.1f)
+                curveToRelative(1.9f, 1.9f, 4.6f, 2.4f, 6.9f, 1.5f)
+                lineToRelative(9.1f, 9.1f)
+                curveToRelative(0.4f, 0.4f, 1f, 0.4f, 1.4f, 0f)
+                lineToRelative(2.3f, -2.3f)
+                curveToRelative(0.5f, -0.4f, 0.5f, -1.1f, 0.1f, -1.4f)
+                close()
+            }
+        }.build()
+    }
+
+    /**
+     * Error icon (circle with X)
+     */
+    val Error: ImageVector by lazy {
+        ImageVector.Builder(
+            name = "Error",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f
+        ).apply {
+            path(
+                fill = SolidColor(Color.Black)
+            ) {
+                moveTo(12f, 2f)
+                curveTo(6.48f, 2f, 2f, 6.48f, 2f, 12f)
+                reflectiveCurveToRelative(4.48f, 10f, 10f, 10f)
+                reflectiveCurveToRelative(10f, -4.48f, 10f, -10f)
+                reflectiveCurveTo(17.52f, 2f, 12f, 2f)
+                close()
+                moveTo(13f, 17f)
+                horizontalLineToRelative(-2f)
+                verticalLineToRelative(-2f)
+                horizontalLineToRelative(2f)
+                verticalLineToRelative(2f)
+                close()
+                moveTo(13f, 13f)
+                horizontalLineToRelative(-2f)
+                lineTo(11f, 7f)
+                horizontalLineToRelative(2f)
+                verticalLineToRelative(6f)
+                close()
+            }
+        }.build()
+    }
+
+    /**
+     * CheckCircle icon (circle with checkmark)
+     */
+    val CheckCircle: ImageVector by lazy {
+        ImageVector.Builder(
+            name = "CheckCircle",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f
+        ).apply {
+            path(
+                fill = SolidColor(Color.Black)
+            ) {
+                moveTo(12f, 2f)
+                curveTo(6.48f, 2f, 2f, 6.48f, 2f, 12f)
+                reflectiveCurveToRelative(4.48f, 10f, 10f, 10f)
+                reflectiveCurveToRelative(10f, -4.48f, 10f, -10f)
+                reflectiveCurveTo(17.52f, 2f, 12f, 2f)
+                close()
+                moveTo(10f, 17f)
+                lineToRelative(-5f, -5f)
+                lineToRelative(1.41f, -1.41f)
+                lineTo(10f, 14.17f)
+                lineToRelative(7.59f, -7.59f)
+                lineTo(19f, 8f)
+                lineToRelative(-9f, 9f)
+                close()
+            }
+        }.build()
+    }
+}
+


### PR DESCRIPTION
## Problem

The IntelliJ plugin was crashing with:
```
java.lang.NoClassDefFoundError: androidx/compose/material/icons/Icons
	at cc.unitmesh.devins.ui.compose.icons.AutoDevComposeIcons.getSettings(AutoDevComposeIcons.kt:36)
	at cc.unitmesh.devins.idea.toolwindow.ComposableSingletons$IdeaAgentAppKt$lambda$1981209179$1.invoke-KMTpdl8(IdeaAgentApp.kt:466)
```

## Root Cause

The `mpp-ui` module's `AutoDevComposeIcons` uses `androidx.compose.material.icons.Icons` (Material Icons), which is available for Android/Multiplatform but **not** in IntelliJ's Compose environment (Jewel UI).

## Solution

Created a local icon provider `IdeaComposeIcons` in `mpp-idea` that defines icons using `ImageVector.Builder` with path-based vector graphics, avoiding the dependency on Material Icons.

### Changes

1. **Created `IdeaComposeIcons.kt`** - A new icon provider that uses `ImageVector.Builder` with paths:
   - `Settings` - gear/cog icon
   - `Build` - wrench icon  
   - `Error` - circle with exclamation mark
   - `CheckCircle` - circle with checkmark

2. **Updated `IdeaAgentApp.kt`**:
   - Removed import of `AutoDevComposeIcons`
   - Changed all usages from `AutoDevComposeIcons.X` to `IdeaComposeIcons.X`

## Testing

- The icons are defined using standard Compose `ImageVector` paths which work with Jewel's `Icon` composable
- No runtime dependencies on Material Icons library

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated UI icons (Settings, Build, Error, and status indicators) for improved visual consistency and better integration with the IDE interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->