### PR TITLE
feat(mpp-idea): redesign IdeaAgentTabsHeader with modern segmented control

### DIFF
--- a/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/toolwindow/IdeaComposeIcons.kt
+++ b/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/toolwindow/IdeaComposeIcons.kt
@@ -795,10 +795,10 @@ object IdeaComposeIcons {
             viewportWidth = 24f,
             viewportHeight = 24f
         ).apply {
+            // Magnifying glass (fill path only, checkmark is drawn separately as stroke)
             path(
                 fill = SolidColor(Color.Black)
             ) {
-                // Magnifying glass
                 moveTo(15.5f, 14f)
                 horizontalLineToRelative(-0.79f)
                 lineToRelative(-0.28f, -0.27f)
@@ -820,11 +820,8 @@ object IdeaComposeIcons {
                 reflectiveCurveTo(14f, 7.01f, 14f, 9.5f)
                 reflectiveCurveTo(11.99f, 14f, 9.5f, 14f)
                 close()
-                // Checkmark inside
-                moveTo(7.5f, 9.5f)
-                lineToRelative(1.5f, 1.5f)
-                lineToRelative(3f, -3f)
             }
+            // Checkmark inside (stroke only to avoid visual artifacts)
             path(
                 stroke = SolidColor(Color.Black),
                 strokeLineWidth = 1.5f,

--- a/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/toolwindow/header/IdeaAgentTabsHeader.kt
+++ b/mpp-idea/src/main/kotlin/cc/unitmesh/devins/idea/toolwindow/header/IdeaAgentTabsHeader.kt
@@ -54,7 +54,7 @@ fun IdeaAgentTabsHeader(
             onAgentTypeChange = onAgentTypeChange
         )
 
-        // Right: Actions with tooltips
+        // Right: Action buttons
         Row(
             horizontalArrangement = Arrangement.spacedBy(2.dp),
             verticalAlignment = Alignment.CenterVertically
@@ -86,6 +86,9 @@ private fun SegmentedAgentTabs(
     onAgentTypeChange: (AgentType) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    // Note: LOCAL_CHAT is intentionally excluded from the tabs as it represents
+    // a different interaction mode (direct local chat without agent routing).
+    // It's handled separately in IdeaAgentApp but not exposed as a user-selectable tab.
     val agentTypes = listOf(AgentType.CODING, AgentType.CODE_REVIEW, AgentType.KNOWLEDGE, AgentType.REMOTE)
 
     Row(


### PR DESCRIPTION
## Summary

Redesigned `IdeaAgentTabsHeader` with a modern, fancy segmented control design featuring smooth animations and visual enhancements.

## Changes

### Visual Improvements
- **Segmented Control Design**: Unified background container with rounded corners wrapping all tabs
- **Animated Bottom Indicator**: Selected tab shows a colored indicator bar with spring animation
- **Hover Effects**: Tabs and action buttons respond to hover with color changes

### Agent Type Theming
Each agent type now has a unique color and icon:

| Agent Type | Color | Icon |
|------------|-------|------|
| Agentic (Coding) | Blue | Code `</>` |
| Review | Indigo | Magnifier with checkmark |
| Knowledge | Green | Book |
| Remote | Amber | Cloud |

### Animation System
- Spring-based physics animations using `animateColorAsState` and `animateDpAsState`
- Smooth transitions for background color, text color, and indicator height
- `Spring.StiffnessMediumLow` for natural feeling transitions

### New Icons
Added to `IdeaComposeIcons`:
- `Add` - Plus icon for new chat button
- `Review` - Magnifying glass with checkmark
- `Book` - Book icon for Knowledge agent
- `Cloud` - Cloud icon for Remote agent
- `Chat` - Chat bubble icon

## Testing

- [x] `./gradlew :mpp-idea:compileKotlin` passes

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned agent tabs with an animated segmented control for clearer, responsive navigation.
  * Added right‑side action buttons for creating new chats and accessing settings.
  * Added five new UI icons (Add, Review, Book, Cloud, Chat) for toolbar and tab use.

* **Bug Fixes**
  * Removed hard‑coded tab rendering in favor of a centralized, consistent tab implementation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->